### PR TITLE
Ensure buttons have four spec states when loading

### DIFF
--- a/Ion/Ion_Buttons.lua
+++ b/Ion/Ion_Buttons.lua
@@ -2999,7 +2999,13 @@ function BUTTON:LoadData(spec, state)
 		end
 
 		if (not self.CDB[id]) then
-			self.CDB[id] = { [1] = { homestate = CopyTable(stateData) }, [2] = { homestate = CopyTable(stateData) } }
+			self.CDB[id] = {}
+		end
+
+		for i=1,4 do
+			if (not self.CDB[id][i]) then
+				self.CDB[id][i] = { homestate = CopyTable(stateData) }
+			end
 		end
 
 		if (not self.CDB[id].keys) then


### PR DESCRIPTION
Pre-patch buttons will not have the requisite number of states. Just add the missing states rather than require the button be re-made, and add four instead of two.