### PR TITLE
Handle drags of spells provided by talents

### DIFF
--- a/Ion/Ion_Buttons.lua
+++ b/Ion/Ion_Buttons.lua
@@ -1778,39 +1778,42 @@ function BUTTON:MACRO_PlaceMacro()
 end
 
 
-function BUTTON:MACRO_PlaceSpell(action1, action2, hasAction)
-	local _, modifier, spell, subName, spellID, texture = " "
+function BUTTON:MACRO_PlaceSpell(action1, action2, spellID, hasAction)
+	local _, modifier, spell, subName, texture = " "
 
 	if (action1 == 0) then
-		return
+		-- I am unsure under what conditions (if any) we wouldn't have a spell ID
+		if not spellID or spellID == 0 then
+			return
+		end
 	else
 		spell, _ = GetSpellBookItemName(action1, action2)
 		_, spellID = GetSpellBookItemInfo(action1, action2)
-		local spellInfoName , subName, icon, castTime, minRange, maxRange= GetSpellInfo(spellID)
-
-		if AlternateSpellNameList[spellID] then
-			self.data.macro_Text = self:AutoWriteMacro(spellInfoName)
-			self.data.macro_Auto = spellInfoName..";"
-		else
-			self.data.macro_Text = self:AutoWriteMacro(spell, subName)
-			self.data.macro_Auto = spell..";"..subName
-		end
-
-		self.data.macro_Icon = false
-		self.data.macro_Name = ""
-		self.data.macro_Watch = false
-		self.data.macro_Equip = false
-		self.data.macro_Note = ""
-		self.data.macro_UseNote = false
-
-		if (not self.cursor) then
-			self:SetType(true)
-		end
-
-		MacroDrag[0] = false
-
-		ClearCursor(); SetCursor(nil)
 	end
+	local spellInfoName , subName, icon, castTime, minRange, maxRange= GetSpellInfo(spellID)
+
+	if AlternateSpellNameList[spellID] or not spell then
+		self.data.macro_Text = self:AutoWriteMacro(spellInfoName)
+		self.data.macro_Auto = spellInfoName..";"
+	else
+		self.data.macro_Text = self:AutoWriteMacro(spell, subName)
+		self.data.macro_Auto = spell..";"..subName
+	end
+
+	self.data.macro_Icon = false
+	self.data.macro_Name = ""
+	self.data.macro_Watch = false
+	self.data.macro_Equip = false
+	self.data.macro_Note = ""
+	self.data.macro_UseNote = false
+
+	if (not self.cursor) then
+		self:SetType(true)
+	end
+
+	MacroDrag[0] = false
+
+	ClearCursor(); SetCursor(nil)
 end
 
 
@@ -2162,7 +2165,7 @@ end
 function BUTTON:MACRO_OnReceiveDrag(preclick)
 	if (InCombatLockdown()) then return end
 
-	local cursorType, action1, action2, ID = GetCursorInfo()
+	local cursorType, action1, action2, spellID = GetCursorInfo()
 
 	--for i=1,select("#",GetCursorInfo()) do
 	--	print(i..": "..select(i,GetCursorInfo()))
@@ -2188,7 +2191,7 @@ function BUTTON:MACRO_OnReceiveDrag(preclick)
 		currMacro.texture = texture
 	end
 
-	if  (action1 == 0) then
+	if  (action1 == 0 and cursorType ~= "spell") then
 		-- do nothing for now
 	else
 
@@ -2197,7 +2200,7 @@ function BUTTON:MACRO_OnReceiveDrag(preclick)
 			self:MACRO_PlaceMacro(); PlaySound("igSpellBookSpellIconDrop")
 
 		elseif (cursorType == "spell") then
-			self:MACRO_PlaceSpell(action1, action2, self:MACRO_HasAction())
+			self:MACRO_PlaceSpell(action1, action2, spellID, self:MACRO_HasAction())
 
 		elseif (cursorType == "item") then
 			self:MACRO_PlaceItem(action1, action2, self:MACRO_HasAction())


### PR DESCRIPTION
It seems that spells provided by talents may not have spellbook info
in the cursor info, I'm not sure why this is. However, the cursor info
does seem to have the spell ID, so we can fall back to using that.

An example spell is the ret paladin spell Blade of Wrath.