### PR TITLE
Don't throw an error about ToyBox on login

### DIFF
--- a/Ion/Ion__Core.lua
+++ b/Ion/Ion__Core.lua
@@ -2269,8 +2269,8 @@ local function control_OnEvent(self, event, ...)
 		ION.level = UnitLevel("player")
 
 	elseif ( event == "TOYS_UPDATED" )then
-		
-		if not ToyBox:IsShown() then print("TVS"); ION:UpdateToyData() end
+
+		if not ToyBox or not ToyBox:IsShown() then print("TVS"); ION:UpdateToyData() end
 	end
 
 end


### PR DESCRIPTION
At least in my setup, Ion is loading and receiving a `TOYS_UPDATED` event before the Blizzard ToyBox has loaded.